### PR TITLE
Single port and dual port examples

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,41 +1,36 @@
 import scala.sys.process._
-// OBS: sbt._ has also process. Importing scala.sys.process 
+// OBS: sbt._ has also process. Importing scala.sys.process
 // and explicitly using it ensures the correct operation
 
-organization := "edu.berkeley.cs"
+ThisBuild / scalaVersion     := "2.13.8"
+ThisBuild / version          := scala.sys.process.Process("git rev-parse --short HEAD").!!.mkString.replaceAll("\\s", "")+"-SNAPSHOT"
+ThisBuild / organization     := "Chisel-blocks"
 
-name := "memblock"
+// Suppresses eviction errors for new sbt versions
+ThisBuild / evictionErrorLevel := Level.Info
 
-version := scala.sys.process.Process("git rev-parse --short HEAD").!!.mkString.replaceAll("\\s", "")+"-SNAPSHOT"
+val chiselVersion = "3.5.1"
 
-scalaVersion := "2.12.10"
+resolvers += "A-Core Gitlab" at "https://gitlab.com/api/v4/groups/13348068/-/packages/maven"
 
-// [TODO] what are these needed for? remove if obsolete
-def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // If we're building with Scala > 2.11, enable the compile option
-    //  switch to support our anonymous Bundle definitions:
-    //  https://github.com/scala/bug/issues/10047
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-      case _ => Seq("-Xsource:2.11")
-    }
-  }
-}
-
-def javacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // Scala 2.12 requires Java 8. We continue to generate
-    //  Java 7 compatible code for Scala 2.11
-    //  for compatibility with old clients.
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
-        Seq("-source", "1.7", "-target", "1.7")
-      case _ =>
-        Seq("-source", "1.8", "-target", "1.8")
-    }
-  }
-}
+lazy val memblock = (project in file("."))
+  .settings(
+    name := "memblock",
+    libraryDependencies ++= Seq(
+      "edu.berkeley.cs" %% "chisel3" % chiselVersion,
+      "edu.berkeley.cs" %% "dsptools" % "1.5.6",
+      "net.jcazevedo" %% "moultingyaml" % "0.4.2"
+    ),
+    scalacOptions ++= Seq(
+      "-language:reflectiveCalls",
+      "-deprecation",
+      "-feature",
+      "-Xcheckinit",
+      "-P:chiselplugin:genBundleElements",
+      "-Ymacro-annotations"
+    ),
+    addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % chiselVersion cross CrossVersion.full)
+  )
 
 // Parse the version of a submodle from the git submodule status
 // for those modules not version controlled by Maven or equivalent
@@ -43,54 +38,4 @@ def gitSubmoduleHashSnapshotVersion(submod: String): String = {
     val shellcommand =  "git submodule status | grep %s | awk '{print substr($1,0,7)}'".format(submod)
     scala.sys.process.Process(Seq("/bin/sh", "-c", shellcommand )).!!.mkString.replaceAll("\\s", "")+"-SNAPSHOT"
 }
-
-
-// [TODO] what are these needed for? remove if obsolete
-crossScalaVersions := Seq("2.11.11", "2.12.10")
-scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
-javacOptions ++= javacOptionsVersion(scalaVersion.value)
-
-// [TODO] what are these needed for? remove if obsolete
-resolvers ++= Seq(
-  Resolver.sonatypeRepo("snapshots"),
-  Resolver.sonatypeRepo("releases")
-)
-// [TODO]: Is this redundant?
-resolvers += "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
-
-// Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
-// [TODO] is simpler clearer?
-val defaultVersions = Map(
-  "chisel3" -> "3.4.0",
-  "chisel-iotesters" -> "1.5.1",
-  "dsptools" -> "1.4.1"
-  )
-
-libraryDependencies ++= (Seq("chisel3","chisel-iotesters","dsptools").map {
-  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })
-
-libraryDependencies  ++= Seq(
-//  // Last stable release
-  "org.scalanlp" %% "breeze" % "0.13.2",
-  
-// Native libraries are not included by default. add this if you want them (as of 0.7)
-  // Native libraries greatly improve performance, but increase jar sizes. 
-  // It also packages various blas implementations, which have licenses that may or may not
-  // be compatible with the Apache License. No GPL code, as best I know.
-  "org.scalanlp" %% "breeze-natives" % "0.13.2",
-  
-  // The visualization library is distributed separately as well.
-  // It depends on LGPL code
-  "org.scalanlp" %% "breeze-viz" % "0.13.2"
-)
-
-// Some common deps in BWRC projects, select if needed
-// TODO-how to figure out what version is the current and the best?
-
-//libraryDependencies += "berkeley" %% "rocketchip" % "1.2"
-//libraryDependencies += "edu.berkeley.eecs" %% "ofdm" % "0.1"
-//libraryDependencies += "edu.berkeley.cs" %% "eagle_serdes" % "0.0-SNAPSHOT"
-
-// Put your git-version controlled snapshots here
-//libraryDependencies += "edu.berkeley.cs" %% "hbwif" % gitSubmoduleHashSnapshotVersion("hbwif")
 

--- a/configure
+++ b/configure
@@ -64,8 +64,15 @@ TEST_TARGETS = \$(foreach name,\$(MODULES), test_\$(name))
 
 #Commands
 SBT=sbt -J-Xmx16G -J-Xss8M
-
 TOUCH=touch -r
+
+# Default parameters
+proto ?= DspComplex(UInt(16.W),UInt(16.W))
+memsize ?= 8198
+dualport ?= true
+
+MAINPARAMS = -memsize \$(memsize)
+
 `for i in ${VPATHDIRS}; do
     echo vpath %.scala \\$\(SCALAPATH\)/$i
 done`
@@ -95,7 +102,7 @@ done`
 	\$(eval package:=\$(basename \$(notdir \$@)))
 	\$(eval class:=\$(basename \$(notdir \$@)))
 	\$(eval testbenchfile:=\$(dir \$<)tb_\$(notdir \$<))
-	\$(SBT) 'runMain \$(PACKAGE).\$(class) -td \$(VERILOGPATH)'
+	\$(SBT) 'runMain \$(PACKAGE).\$(class) \$(MAINPARAMS) -td \$(VERILOGPATH)'
 	@#Test if testbech generator exists and compile it
 	@if [ -f \$(testbenchfile) ]; then \\
 		\$(SBT) 'runMain \$(package).tb_\$(class) -td \$(VERILOGPATH)'; \\

--- a/configure
+++ b/configure
@@ -71,7 +71,8 @@ proto ?= DspComplex(UInt(16.W),UInt(16.W))
 memsize ?= 8198
 dualport ?= true
 
-MAINPARAMS = -memsize \$(memsize)
+MAINPARAMS = -memsize \$(memsize) \\
+    -dualport \$(dualport)
 
 `for i in ${VPATHDIRS}; do
     echo vpath %.scala \\$\(SCALAPATH\)/$i

--- a/configure
+++ b/configure
@@ -67,12 +67,13 @@ SBT=sbt -J-Xmx16G -J-Xss8M
 TOUCH=touch -r
 
 # Default parameters
-proto ?= DspComplex(UInt(16.W),UInt(16.W))
 memsize ?= 8198
 dualport ?= true
 
-MAINPARAMS = -memsize \$(memsize) \\
-    -dualport \$(dualport)
+MAINPARAMS = -memsize \$(memsize) -dualport \$(dualport)
+
+#Default module for memory mapping
+MMOD ?= memblock
 
 `for i in ${VPATHDIRS}; do
     echo vpath %.scala \\$\(SCALAPATH\)/$i
@@ -115,10 +116,9 @@ clean:
 	rm -rf \$(VERILOGPATH)
 	#rm -rf \$(DEPDIR)
 
-MMOD ?=
 memmap:
 	cp \$(VERILOGPATH)/\$(MMOD).v  \$(VERILOGPATH)/\$(MMOD)_unmapped.orig.v
-	\$(SBT) 'runMain \$(PACKAGE).\$(MMOD) -td \$(VERILOGPATH) --infer-rw \$(MMOD) --repl-seq-mem -c:\$(MMOD):-o:\$(VERILOGPATH)/\$(MMOD).conf'
+	\$(SBT) 'runMain \$(PACKAGE).\$(MMOD) \$(MAINPARAMS) -td \$(VERILOGPATH) --infer-rw \$(MMOD) --repl-seq-mem -c:\$(MMOD):-o:\$(VERILOGPATH)/\$(MMOD).conf'
 
 #Generate cleanup recipes for individual modules
 `for i in ${MODULES}; do

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.8.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addDependencyTreePlugin

--- a/src/main/scala/memblock/memblock.scala
+++ b/src/main/scala/memblock/memblock.scala
@@ -109,7 +109,7 @@ object memblock extends App {
 
     val annos = Seq(ChiselGeneratorAnnotation(() => new memblock(
         proto=DspComplex(UInt(16.W),UInt(16.W)), options("memsize").toInt, 
-        dualport=true
+        dualport=options("dualport").toBoolean
     ))) 
     (new ChiselStage).execute(arguments.toArray, annos)
 }

--- a/src/main/scala/memblock/memblock.scala
+++ b/src/main/scala/memblock/memblock.scala
@@ -108,7 +108,7 @@ object memblock extends App {
     val (options,arguments)= getopts(defaultoptions,args.toList)
 
     val annos = Seq(ChiselGeneratorAnnotation(() => new memblock(
-        proto=DspComplex(UInt(16.W),UInt(16.W)), 8192, 
+        proto=DspComplex(UInt(16.W),UInt(16.W)), options("memsize").toInt, 
         dualport=true
     ))) 
     (new ChiselStage).execute(arguments.toArray, annos)

--- a/src/main/scala/memblock/memblock.scala
+++ b/src/main/scala/memblock/memblock.scala
@@ -40,7 +40,7 @@ class memblock[T <:Data] (
 //This gives you verilog
 object memblock extends App {
    // Generate verilog
-    val annos = Seq(ChiselGeneratorAnnotation(() => new  memblock(proto=DspComplex(FixedPoint(8.W,4.BP)), memsize=scala.math.pow(2,13).toInt))))
+    val annos = Seq(ChiselGeneratorAnnotation(() => new  memblock(proto=DspComplex(FixedPoint(8.W,4.BP)), memsize=scala.math.pow(2,13).toInt)))
     val sysverilog = (new ChiselStage).emitSystemVerilog(
         new memblock(proto=DspComplex(FixedPoint(8.W,4.BP)), memsize=scala.math.pow(2,13).toInt))
 }

--- a/src/main/scala/memblock/memblock.scala
+++ b/src/main/scala/memblock/memblock.scala
@@ -72,7 +72,6 @@ object memblock extends App {
             |     h                          : This help 
           """.stripMargin
         val optsWithArg: List[String]=List(
-            "-proto",
             "-memsize",
             "-dualport"
         )
@@ -100,7 +99,6 @@ object memblock extends App {
      
     // Default options
     val defaultoptions : Map[String,String]=Map(
-        "proto"->"DspComplex(UInt(16.W),UInt(16.W))",
         "memsize"->"8192",
         "dualport"->"true"
         ) 
@@ -108,7 +106,8 @@ object memblock extends App {
     val (options,arguments)= getopts(defaultoptions,args.toList)
 
     val annos = Seq(ChiselGeneratorAnnotation(() => new memblock(
-        proto=DspComplex(UInt(16.W),UInt(16.W)), options("memsize").toInt, 
+        proto=DspComplex(UInt(16.W),UInt(16.W)), 
+        options("memsize").toInt, 
         dualport=options("dualport").toBoolean
     ))) 
     (new ChiselStage).execute(arguments.toArray, annos)

--- a/src/main/scala/memblock/memblock.scala
+++ b/src/main/scala/memblock/memblock.scala
@@ -32,6 +32,8 @@ class memblock[T <:Data] (
         write_enable:=io.write_en
         write_val:=io.write_val
         read_addr:=io.read_addr
+        // [ ToDo] Create structural alternatives to control whether the operation
+        // Aims for single or dual port memory
         when(write_enable){ 
             mem.write(write_addr,write_val)
         }

--- a/src/main/scala/memblock/memblock.scala
+++ b/src/main/scala/memblock/memblock.scala
@@ -1,9 +1,12 @@
 // See LICENSE for license details.
 // Initially written by Marko Kosunen  20180429
 package memblock 
+
 import chisel3._
 import chisel3.util._
 import chisel3.experimental._
+import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
+import chisel3.stage.ChiselGeneratorAnnotation
 import dsptools._
 import dsptools.numbers._
 import scala.math._

--- a/src/main/scala/memblock/memblock.scala
+++ b/src/main/scala/memblock/memblock.scala
@@ -58,7 +58,8 @@ class memblock[T <:Data] (
 /** This gives you verilog */
 object memblock extends App {
     val annos = Seq(ChiselGeneratorAnnotation(() => new memblock(
-        proto=DspComplex(UInt(16.W),UInt(16.W)), memsize=4096
+        proto=DspComplex(UInt(16.W),UInt(16.W)), memsize=4096, 
+        dualport=true
     ))) 
     (new ChiselStage).execute(args, annos)
 }

--- a/src/main/scala/memblock/memblock.scala
+++ b/src/main/scala/memblock/memblock.scala
@@ -39,10 +39,10 @@ class memblock[T <:Data] (
 }
 //This gives you verilog
 object memblock extends App {
-  val proto=DspComplex(FixedPoint(8.W,4.BP))
-  chisel3.Driver.execute(args, () => 
-          new memblock(proto, memsize=scala.math.pow(2,13).toInt)
-  )
+   // Generate verilog
+    val annos = Seq(ChiselGeneratorAnnotation(() => new  memblock(proto=DspComplex(FixedPoint(8.W,4.BP)), memsize=scala.math.pow(2,13).toInt))))
+    val sysverilog = (new ChiselStage).emitSystemVerilog(
+        new memblock(proto=DspComplex(FixedPoint(8.W,4.BP)), memsize=scala.math.pow(2,13).toInt))
 }
 
 


### PR DESCRIPTION
 Create structural alternatives to control whether the operation aims for single or dual port memory implementation. 
 
 Determine the default (single or dual)
 
 Relates to #1 
